### PR TITLE
Added Browser Alerts for Geolocation error

### DIFF
--- a/static/admin/js/map.js
+++ b/static/admin/js/map.js
@@ -1,4 +1,4 @@
-            var map;
+var map;
 
             function initMap() {
               if (navigator.geolocation) {
@@ -9,7 +9,22 @@
                       lng: position.coords.longitude
                     };
                     setPos(myLocation);
-                  });
+                  },
+                    function(error){
+                    switch(error.code){
+                        case 1:
+                            alert("Please enable geolocation permission in your browser settings to view this page");
+                            break;
+                        case 2:
+                            alert("There seems to be a problem getting the location. Check if GPS is enabled");
+                            break;
+                        case 3:
+                            alert("Getting your location timed out. Please try again.");
+                            break;        
+                    }
+                    console.log(error.message);            
+                });
+                  //
                 } catch (err) {
                   var myLocation = {
                     lat: 23.8701334,
@@ -75,5 +90,3 @@
               }
               map.fitBounds(bounds);
             }
-
-            


### PR DESCRIPTION
I have tested the code on chrome dev tools on Windows for the following scenarios:

1. GPS enabled but user denied permission: Alerts user to enable geolocation permission.
2. GPS disabled and user denied permission: Alerts user to enable geolocation permission.
3. GPS disabled but user gives permission: Alerts user that there was a problem and to check if GPS is enabled.
Please let me know what you think :)