### PR TITLE
[ISSUE-11] Adding support to run the web application via docker-compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ local_settings.py
 
 .env
 db.sqlite3
+
+# IDE
+.idea/

--- a/README.md
+++ b/README.md
@@ -113,10 +113,22 @@ python manage.py runserver
 Note : The live demo hasn't been updated in an year. 
 </a>
 
-### Docker 
+### Docker
+
+The web application can be run within docker using [docker-compose](https://docs.docker.com/install/overview/).
+
+To build and run the application:
 
 ```
-docker build -t "cbt/therapy:1.0"
-docker run -d -p 8080:8000 --name cbt_1 cbt/therapy:1.0
+docker-compose up -- build
 ```
-* Access at http://localhost:8080/
+
+Run the following commands in another terminal (once the application is running) to collect static files and import initial data into the application:
+
+```
+docker-compose run service python manage.py collectstatic
+docker-compose run service python manage.py loaddata therapist.json
+docker-compose run service python manage.py loaddata drawing_challenges.json
+```
+
+* Access at http://localhost:8000/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.7'
+
+services:
+  service:
+    build: .
+    command: python manage.py runserver 0.0.0.0:8000
+    environment:
+      - DEBUG=true
+      - DJANGO_SETTINGS_MODULE=CBT_therapy.settings
+      - LOG_LEVEL=debug
+      - SECRET_KEY
+    ports:
+      - "0.0.0.0:8000:8000"
+      - "0.0.0.0:8125:8125"
+    volumes:
+      - "./:/usr/src/app"


### PR DESCRIPTION
### What's Changed

Adds support to run the application with docker using docker-compose. 

![image](https://user-images.githubusercontent.com/1443700/67141094-10897b00-f258-11e9-9b01-1d8e95003491.png)

### Technical Description

Running the application with docker allows for new developers to the project to quickly get set up with a working environment (with the assumption they have docker installed) using the `docker-compose up --build` command.

* Replaced the `Dockerfile` with an updated version using Python 3.7.3
* Adds `docker-compose.yml` to allow the service to be run in a docker container
* Adds Pycharm `.idea/` directory to gitignore file to avoid these files being committed
* Updates README with steps on how to start the application with docker

The application running within docker on `http://localhost:8000`:

![image](https://user-images.githubusercontent.com/1443700/67141106-26973b80-f258-11e9-865b-a8c63d04a13b.png)

Resolves #11 and opens #12 
